### PR TITLE
Filenames are stripped of extensions

### DIFF
--- a/app/models/build/transformer.rb
+++ b/app/models/build/transformer.rb
@@ -129,8 +129,6 @@ module Build
       Path.new(new_img.to_s.sub(/.*?vendor\/assets\/images\//, ""))
     end
 
-    private
-
     def process_asset(file_name, source, transformations)
       return source if file_name.nil?
 
@@ -149,8 +147,8 @@ module Build
         javascripts: {
           extension: 'js',
           processor: lambda { |files|
-            files.map do |file_name|
-              "//= require #{file_name.to_s[/\/?([^\/]*\/)*[^\.]+/]}"
+            files.map do |filename|
+              "//= require #{shorten_filename(filename, Path.extension_classes[:javascripts])}"
             end.join("\n")
           }
         },
@@ -158,13 +156,19 @@ module Build
           extension: 'css',
           processor: lambda { |files|
             "/*\n" +
-            files.map { |file_name|
-              " *= require #{file_name.to_s[/\/?([^\/]*\/)*[^\.]+/]}"
+            files.map { |filename|
+              " *= require #{shorten_filename(filename, Path.extension_classes[:stylesheets])}"
             }.join("\n") +
             "\n */"
           }
         }
       }
+    end
+
+    def shorten_filename(filename, extensions)
+      filename.to_s.split('.').reverse.
+        drop_while { |e| extensions.include?(e.downcase) }.
+        reverse.join('.')
     end
   end
 end

--- a/spec/models/build/transformer_spec.rb
+++ b/spec/models/build/transformer_spec.rb
@@ -151,5 +151,39 @@ module Build
         )).to eq(Path.new('fiz/img.png'))
       end
     end
+
+    context '#shorten_filename' do
+      it 'leaves custom extensions' do
+        filename = Transformer.shorten_filename(
+          'jquery.cookie.css', Path.extension_classes[:stylesheets]
+        )
+
+        expect(filename).to eq('jquery.cookie')
+      end
+      
+      it 'removes all non-custom extension' do
+        filename = Transformer.shorten_filename(
+          'jquery.js.cookie.css.scss', Path.extension_classes[:stylesheets]
+        )
+
+        expect(filename).to eq('jquery.js.cookie')
+      end
+
+      it 'also deals with paths' do
+        filename = Transformer.shorten_filename(
+          '/foo/bar/jquery.cookie.sass', Path.extension_classes[:stylesheets]
+        )
+
+        expect(filename).to eq('/foo/bar/jquery.cookie')
+      end
+
+      it 'deals with Path object' do
+        filename = Transformer.shorten_filename(
+          Path.new('/jquery.cookie.sass'), Path.extension_classes[:stylesheets]
+        )
+
+        expect(filename).to eq('/jquery.cookie')
+      end
+    end
   end
 end

--- a/spec/models/builder_spec.rb
+++ b/spec/models/builder_spec.rb
@@ -40,6 +40,12 @@ describe Build::Convert do
       expect(ex).to eq true
     end
 
+    def file_contains(path, fragment)
+      log "Checking contents of #{path}"
+      contents = File.read(File.join(@gem_root, path))
+      expect(contents).to include(fragment)
+    end
+
     component "angular", "1.2.0-rc.1" do
       gem_file "vendor/assets/javascripts/angular.js"
       gem_file "vendor/assets/javascripts/angular/angular.js"
@@ -53,6 +59,7 @@ describe Build::Convert do
     component "sugar", "1.3.9" do
       gem_file "vendor/assets/javascripts/sugar.js"
       gem_file "vendor/assets/javascripts/sugar/sugar-full.development.js"
+      file_contains 'vendor/assets/javascripts/sugar.js', 'sugar/sugar-full.development'
     end
 
     component "purl", "2.3.1" do
@@ -96,5 +103,13 @@ describe Build::Convert do
       gem_file "vendor/assets/stylesheets/selectize.scss"
       gem_file "vendor/assets/stylesheets/selectize/selectize.scss"
     end
+
+    ## Currently fails because jquery.cookie ignores package.json
+    # component "jquery.cookie", '1.4.0' do
+    #   gem_file "vendor/assets/javascripts/jquery.cookie.js"
+    #   gem_file "vendor/assets/javascripts/jquery-cookie/jquery.cookie.js"
+    #   file_contains 'vendor/assets/javascripts/jquery.cookie.js',
+    #     'require jquery-cookie/jquery.cookie'
+    # end
   end
 end


### PR DESCRIPTION
In manifest we remove for example js extension so //= require file.js becomes //= require file. Unfortunately we strip all extensions so jquery.cookie.js becomes jquery
