### PR TITLE
Remove group :assets

### DIFF
--- a/app/views/shared/_diff_gemfile.html
+++ b/app/views/shared/_diff_gemfile.html
@@ -6,10 +6,10 @@
  gem 'rails'
 
  # Assets
-   gem 'sass-rails'
-   gem 'uglifier'
-   gem 'coffee-rails'
-<span class="diff__added-line diff__added-line--first"><b>+</b>  gem 'rails-assets-bootstrap'</span>
-<span class="diff__added-line"><b>+</b>  gem 'rails-assets-angular'</span>
-<span class="diff__added-line diff__added-line--last"><b>+</b>  gem 'rails-assets-leaflet'</span>
+ gem 'sass-rails'
+ gem 'uglifier'
+ gem 'coffee-rails'
+<span class="diff__added-line diff__added-line--first"><b>+</b>gem 'rails-assets-bootstrap'</span>
+<span class="diff__added-line"><b>+</b>gem 'rails-assets-angular'</span>
+<span class="diff__added-line diff__added-line--last"><b>+</b>gem 'rails-assets-leaflet'</span>
  </code></pre>

--- a/app/views/shared/_diff_gemfile.html
+++ b/app/views/shared/_diff_gemfile.html
@@ -5,11 +5,11 @@
 
  gem 'rails'
 
- group :assets do
+ # Assets
    gem 'sass-rails'
    gem 'uglifier'
    gem 'coffee-rails'
 <span class="diff__added-line diff__added-line--first"><b>+</b>  gem 'rails-assets-bootstrap'</span>
 <span class="diff__added-line"><b>+</b>  gem 'rails-assets-angular'</span>
 <span class="diff__added-line diff__added-line--last"><b>+</b>  gem 'rails-assets-leaflet'</span>
- end</code></pre>
+ </code></pre>


### PR DESCRIPTION
group :assets is depreciated in Rails 4 and was a hack for Rails 3. Its safe to remove :)
