### PR TITLE
Update gem directive to use single-quotes

### DIFF
--- a/app/views/components/index.html.slim
+++ b/app/views/components/index.html.slim
@@ -26,7 +26,7 @@ section.section.gem-list ng-controller="IndexCtrl"
               a ng-bind="version" ng-click="fetchAssets(version)" style="cursor: pointer" title="Available files"
               | {{{true: '', false: ', '}[$last]}}
         code.gem__code
-          | gem "rails-assets-{{ gem.name }}"
+          | gem 'rails-assets-{{ gem.name }}'
 
         div ng-show="jsManifest" style="margin-top: 10px"
           h5 Include following in application.js:


### PR DESCRIPTION
To match the [Ruby style guide](https://github.com/bbatsov/ruby-style-guide#strings), I've changed the gem commands to use single-quotes.
