### PR TITLE
Adding .cur (cursor file) as an image extension

### DIFF
--- a/app/models/build/path.rb
+++ b/app/models/build/path.rb
@@ -2,12 +2,12 @@ module Build
 
   class Path < Pathname
 
-    # Extensioins are sorted by priority
+    # Extensions are sorted by priority
     def self.extension_classes
       {
         javascripts: ['coffee', 'js', 'json'],
         stylesheets: ['sass', 'scss', 'less', 'css', 'styl'],
-        images: ['png', 'jpg', 'jpeg', 'gif'],
+        images: ['png', 'jpg', 'jpeg', 'gif', 'cur'],
         fonts: ['woff', 'ttf', 'otf', 'eot', 'svg']
       }
     end


### PR DESCRIPTION
The `signature-pad` Bower package uses a `.cur` file, so I would like to add that extension.  I thought the best place to put this was in `images` because the `.cur` file is a picture of a cursor.
