### PR TITLE
Add assets precompile paths of images and fonts in Rails Engine

### DIFF
--- a/app/models/build/templates/lib/GEM.rb.erb
+++ b/app/models/build/templates/lib/GEM.rb.erb
@@ -8,6 +8,11 @@ if defined?(Rails)
   module <%= gem.module %>
     class Engine < ::Rails::Engine
       # Rails -> use vendor directory.
+      initializer "<%= gem.name %>.assets.precompile" do |app|
+        app.config.assets.precompile << Proc.new do |path, fn|
+          fn =~ /vendor\/assets\/(images|fonts)\/<%= gem.short_name %>/ && !%w(.js .css).include?(File.extname(path))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes #96.

> Currently, rails-assets places font files under vendor/assets/fonts/.
> 
> However, in Rails 4 asset precompile, by default, only non-js/css files under app/assets/ are included [1]. Font files under vendor/assets/fonts are not included by default.

Similarly, image files are placed under /vendor/assets/images/.

For example, according to bootstrap-sass, this problem is resolved by adding paths in the Engine.
https://github.com/twbs/bootstrap-sass/blob/master/lib/bootstrap-sass/engine.rb
#96 also made a similar proposal.

Therefore, I've implemented in this way. There may be objections to this matcher of paths.
