### PR TITLE
Spaces around the URL & within the braces are OK

### DIFF
--- a/app/models/build/transformer.rb
+++ b/app/models/build/transformer.rb
@@ -148,7 +148,7 @@ module Build
         {images: :image, fonts: :font}.each do |ext_class, asset_type|
           extensions = Path.extension_classes.fetch(ext_class)
           new_source.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
-          new_source.gsub! /(?<!-)url\((["'\s]*)([^\)]+\.(?:#{extensions.join('|')}))(\??#?[^"'\)]*)\1\)/i do |match|
+          new_source.gsub! /(?<!-)url\(\s*(["']*)([^\)]+\.(?:#{extensions.join('|')}))(\??#?[^\s"'\)]*)\1\s*\)/i do |match|
 
             "#{asset_type}-url(\"#{transform_relative_path(ext_class, $2, file_name, transformations)}#{$3}\")"
 

--- a/spec/models/build/transformer_spec.rb
+++ b/spec/models/build/transformer_spec.rb
@@ -200,6 +200,9 @@ module Build
         transformations = Hash[[
           [source_file, target_file],
           [Path.new('foo/bar.png'), Path.new('vendor/assets/images/foo.png')],
+          [Path.new('foo/before.png'), Path.new('vendor/assets/images/before.png')],
+          [Path.new('foo/around.png'), Path.new('vendor/assets/images/around.png')],
+          [Path.new('foo/after.png'), Path.new('vendor/assets/images/after.png')],
           [Path.new('foo/spam.eot'), Path.new('vendor/assets/fonts/spam.eot')],
           [Path.new('foo/spam.woff'), Path.new('vendor/assets/fonts/spam.woff')],
           [Path.new('foo/spam.ttf'), Path.new('vendor/assets/fonts/spam.ttf')],
@@ -216,11 +219,17 @@ module Build
           }
         }
         body{background-image:url(foo/bar.png)}
+        body{background-image:url( foo/before.png)}
+        body{background-image:url( foo/around.png )}
+        body{background-image:url(foo/after.png )}
         CSS
 
         File.write('/tmp/style.css', css_sample)
         FileUtils.mkdir_p('/tmp/foo')
         File.write('/tmp/foo/bar.png', "BINARY")
+        File.write('/tmp/foo/before.png', "BINARY")
+        File.write('/tmp/foo/around.png', "BINARY")
+        File.write('/tmp/foo/after.png', "BINARY")
         %w(eot woff ttf otf svg).each do |font_ext|
           File.write("/tmp/foo/spam.#{font_ext}", "BINARY")
         end
@@ -229,6 +238,9 @@ module Build
         actual_content = File.read('/tmp/style.scss')
         [
           'background-image:image-url("foo.png")',
+          'background-image:image-url("before.png")',
+          'background-image:image-url("around.png")',
+          'background-image:image-url("after.png")',
           'src:font-url("spam.eot")',
           'src: font-url("spam.eot?#iefix") format(\'embedded-opentype\')',
           'font-url("spam.woff") format(\'woff\')',

--- a/spec/models/builder_spec.rb
+++ b/spec/models/builder_spec.rb
@@ -196,5 +196,12 @@ describe Build::Converter do
       gem_file "vendor/assets/javascripts/marionette.js"
       gem_file "vendor/assets/javascripts/marionette/backbone.marionette.js"
     end
+
+    component "building-blocks", "1.3.1" do
+      # This line failed to parse correctly because of a space
+      # before the url. The original `url( building-blocks/...)`,
+      # was being converted to `url(.)`
+      file_contains "vendor/assets/stylesheets/building-blocks/style/buttons.scss", "background: image-url(\"building-blocks/style/buttons/images/ui/shadow.png\") repeat-x left bottom / auto 100%;"
+    end
   end
 end


### PR DESCRIPTION
### What?

On CSS files, asset links were not converted correctly if there was an space before or after the URL, but inside the braces. For example, in the package "building-blocks", the following line:

```
background: url( buttons/images/ui/shadow.png) repeat-x left bottom / auto 100%;
```

Was being converted to:

```
background: image-url(".") repeat-x left bottom / auto 100%;
```
### How?

The culprit was the regular expression that parses those links, found in `Build::Transformer#process_asset`. Changing it to allow for spaces within the braces, around the URL, solved the problem.
### Specs?

I was first able to reproduce this on the specs by adding a check on `spec/models/builder_spec.rb`. From there, I isolated the problem and added a unit test on `spec/models/build/transformer_spec.rb` before fixing the code.
### Improvements?

The regular expression is complex enough to deserve more focused unit tests. Perhaps moving the code in `#process_asset` to a separate class that can be tested on its own.
### One more thing...

Should this pull request be accepted&merged, could you please rebuild the gem `rails-assets-building-blocks` after deployment? 0:-)

Thank you!
