### PR TITLE
Fix for Incorrect range converting with tilda "~" and "x"

### DIFF
--- a/app/models/build/utils.rb
+++ b/app/models/build/utils.rb
@@ -94,7 +94,7 @@ module Build
       else
 
         if version.match(/\.x/)
-          version.gsub!(/\.x/, '.0')
+          version.gsub!(/\.x/, '')
 
           unless version.include?('>') || version.include?('^')
             version = "~> #{version.gsub('~', '')}"

--- a/app/models/build/utils.rb
+++ b/app/models/build/utils.rb
@@ -94,6 +94,10 @@ module Build
       else
 
         if version.match(/\.x/)
+          # if it is the middle number
+          version.match(/\.x\./) ?
+            version.gsub!(/\.x/, '.0') : nil
+
           version.gsub!(/\.x/, '')
 
           unless version.include?('>') || version.include?('^')

--- a/spec/models/build/utils_spec.rb
+++ b/spec/models/build/utils_spec.rb
@@ -44,11 +44,11 @@ module Build
       end
 
       specify do
-        expect(Utils.fix_version_string('2.3.x')).to eq('~> 2.3.0')
+        expect(Utils.fix_version_string('2.3.x')).to eq('~> 2.3')
       end
 
       specify do
-        expect(Utils.fix_version_string('v2.3.x')).to eq('~> 2.3.0')
+        expect(Utils.fix_version_string('v2.3.x')).to eq('~> 2.3')
       end
 
       specify do
@@ -72,19 +72,19 @@ module Build
       end
 
       specify do
-        expect(Utils.fix_version_string('~1.x')).to eq('~> 1.0')
+        expect(Utils.fix_version_string('~1.x')).to eq('~> 1')
       end
 
       specify do
-        expect(Utils.fix_version_string('1.x')).to eq('~> 1.0')
+        expect(Utils.fix_version_string('1.x')).to eq('~> 1')
       end
 
       specify do
-        expect(Utils.fix_version_string('~1.*')).to eq('~> 1.0')
+        expect(Utils.fix_version_string('~1.*')).to eq('~> 1')
       end
 
       specify do
-        expect(Utils.fix_version_string('1.*')).to eq('~> 1.0')
+        expect(Utils.fix_version_string('1.*')).to eq('~> 1')
       end
 
       specify do
@@ -153,7 +153,7 @@ module Build
 
       specify do
         expect(Utils.fix_version_string('~v1.0.x')).
-          to eq("~> 1.0.0")
+          to eq("~> 1.0")
       end
 
       specify do
@@ -179,7 +179,7 @@ module Build
 
       specify do
         expect(Utils.fix_version_string('^1.2.x')).
-          to eq(">= 1.2.0, < 2")
+          to eq(">= 1.2, < 2")
       end
 
       specify do

--- a/spec/models/build/utils_spec.rb
+++ b/spec/models/build/utils_spec.rb
@@ -48,6 +48,10 @@ module Build
       end
 
       specify do
+        expect(Utils.fix_version_string('2.x.3')).to eq('~> 2.0.3')
+      end
+
+      specify do
         expect(Utils.fix_version_string('v2.3.x')).to eq('~> 2.3')
       end
 


### PR DESCRIPTION
Fix of the issue #284 

Change the version number parsing. The changes were done since the new wanted behaviour is that if the version given by the user is of the form '~1.x.x' instead of returning '~> 1.0.0' it returns  '~> 1'. 

This fix does not support version written like "~1.x.3" in this case the output will be inaccurate and will return "~> 1.3"

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rails-assets/rails-assets/298)

<!-- Reviewable:end -->
