### PR TITLE
Fix for packages with a dot on the name and corresponding tests

### DIFF
--- a/app/models/build/transformer.rb
+++ b/app/models/build/transformer.rb
@@ -218,7 +218,20 @@ module Build
     end
 
     def manifest_path(gem_name, generator)
-      "#{gem_name}.#{generator[:extension]}"
+      revised_gem_name = check_gem_name(gem_name)
+      "#{revised_gem_name}.#{generator[:extension]}"
+    end
+
+    # Verify that the name does not include a dot so that
+    # the resulting file doesn't get a wrong filename
+    #
+    # gem_name: A String containing the name of the gem we will create
+    #
+    # Returns String with the verified name
+    def check_gem_name(gem_name)
+      revised_gem_name = gem_name.split(/\./)
+      revised_gem_name.first
     end
   end
 end
+

--- a/app/models/build/transformer.rb
+++ b/app/models/build/transformer.rb
@@ -218,19 +218,24 @@ module Build
     end
 
     def manifest_path(gem_name, generator)
-      revised_gem_name = check_gem_name(gem_name)
-      "#{revised_gem_name}.#{generator[:extension]}"
+      extension = generator[:extension]
+      revised_gem_name = check_gem_name(gem_name, extension)
+      "#{revised_gem_name}.#{extension}"
     end
 
     # Verify that the name does not include a dot so that
     # the resulting file doesn't get a wrong filename
     #
     # gem_name: A String containing the name of the gem we will create
+    # extension: A String containing the type of extension this file of the gem
+    #            has
     #
     # Returns String with the verified name
-    def check_gem_name(gem_name)
+    def check_gem_name(gem_name, extension)
       revised_gem_name = gem_name.split(/\./)
-      revised_gem_name.first
+      revised_gem_name.last.eql?(extension) ?
+        revised_gem_name.first :
+        gem_name
     end
   end
 end

--- a/spec/models/build/transformer_spec.rb
+++ b/spec/models/build/transformer_spec.rb
@@ -91,7 +91,7 @@ module Build
           targets(['foo.css'], ['foo.css'])
         ).to eq(Paths.new([
           'app/assets/stylesheets/foobar.js/foo.scss',
-          'app/assets/stylesheets/foobar.scss'
+          'app/assets/stylesheets/foobar.js.scss'
         ]))
       end
 
@@ -99,14 +99,14 @@ module Build
         expect(
           mappings(
             ['foo.css'], ['foo.css']
-          )['app/assets/stylesheets/foobar.scss']
+          )['app/assets/stylesheets/foobar.js.scss']
         ).to include("@import 'foobar.js/foo.scss';")
       end
 
       it 'generates proper stylesheet manifest (font-awesome case)' do
         maps = mappings(
           ['css/foo.css', 'scss/foo.scss'], ['css/foo.css']
-        )['app/assets/stylesheets/foobar.scss']
+        )['app/assets/stylesheets/foobar.js.scss']
 
         expect(maps).to include("@import 'foobar.js/foo.scss';")
       end
@@ -115,7 +115,7 @@ module Build
         maps = mappings(
           ['css/foo.css', 'scss/foo.scss'],
           ['css/foo.css', 'scss/foo.scss'],
-        )['app/assets/stylesheets/foobar.scss']
+        )['app/assets/stylesheets/foobar.js.scss']
 
         expect(maps).to include("@import 'foobar.js/css/foo.scss';")
         expect(maps).to include("@import 'foobar.js/scss/foo.scss';")
@@ -135,7 +135,7 @@ module Build
           targets(['dist/css/foo.css'], ['dist/css/foo.css'])
         ).to eq(Paths.new([
           'app/assets/stylesheets/foobar.js/foo.scss',
-          'app/assets/stylesheets/foobar.scss'
+          'app/assets/stylesheets/foobar.js.scss'
         ]))
       end
 
@@ -149,7 +149,7 @@ module Build
           'app/assets/javascripts/foobar.js/foo.js',
           'app/assets/javascripts/foobar.js',
           'app/assets/stylesheets/foobar.js/foo.scss',
-          'app/assets/stylesheets/foobar.scss'
+          'app/assets/stylesheets/foobar.js.scss'
         ]))
       end
 
@@ -162,7 +162,7 @@ module Build
         ).to eq(Paths.new([
           'app/assets/javascripts/foobar.js/dist/js/foo.js',
           'app/assets/stylesheets/foobar.js/foo.scss',
-          'app/assets/stylesheets/foobar.scss'
+          'app/assets/stylesheets/foobar.js.scss'
         ]))
       end
 

--- a/spec/models/build/transformer_spec.rb
+++ b/spec/models/build/transformer_spec.rb
@@ -5,7 +5,7 @@ module Build
     context '#compute_transformations' do
       def targets(asset_paths, main_paths = [])
         Paths.new(Transformer.compute_transformations(
-          'foobar',
+          'foobar.js',
           Paths.new(asset_paths),
           Paths.new(main_paths)
         )[:all].map(&:last))
@@ -13,7 +13,7 @@ module Build
 
       def mappings(asset_paths, main_paths = [])
         Hash[Transformer.compute_transformations(
-          'foobar',
+          'foobar.js',
           Paths.new(asset_paths),
           Paths.new(main_paths)
         )[:all].map { |s, t| [t.to_s, s.to_s] }]
@@ -22,58 +22,58 @@ module Build
       it 'puts javascript files to javascripts directory' do
         expect(
           targets(['foo.js'])
-        ).to eq(Paths.new(['app/assets/javascripts/foobar/foo.js']))
+        ).to eq(Paths.new(['app/assets/javascripts/foobar.js/foo.js']))
       end
 
       it 'puts stylesheet files to stylesheets directory' do
         expect(
           targets(['foo.css'])
         ).to eq(Paths.new([
-          'app/assets/stylesheets/foobar/foo.scss'
+          'app/assets/stylesheets/foobar.js/foo.scss'
         ]))
       end
 
       it 'puts image files to images directory' do
         expect(
           targets(['foo.png'])
-        ).to eq(Paths.new(['app/assets/images/foobar/foo.png']))
+        ).to eq(Paths.new(['app/assets/images/foobar.js/foo.png']))
       end
 
       it 'ignores minified files' do
         expect(
           targets(['foo.min.js', 'foo.js'])
-        ).to eq(Paths.new(['app/assets/javascripts/foobar/foo.js']))
+        ).to eq(Paths.new(['app/assets/javascripts/foobar.js/foo.js']))
       end
 
       it 'ignores gzip, map and nuspec files' do
         expect(
           targets(['foo.min.js.gzip', 'foo.js.nuspec', 'foo.js.map', 'foo.nuspec.js'])
-        ).to eq(Paths.new(['app/assets/javascripts/foobar/foo.nuspec.js']))
+        ).to eq(Paths.new(['app/assets/javascripts/foobar.js/foo.nuspec.js']))
       end
 
       it 'ignores bower.json' do
         expect(
           targets(['bower.json', 'foo.json'])
-        ).to eq(Paths.new(['app/assets/documents/foobar/foo.json']))
+        ).to eq(Paths.new(['app/assets/documents/foobar.js/foo.json']))
       end
 
       it 'ignores node_modules' do
         expect(
           targets(['dist/node_modules/foo.js', 'foo.json'])
-        ).to eq(Paths.new(['app/assets/documents/foobar/foo.json']))
+        ).to eq(Paths.new(['app/assets/documents/foobar.js/foo.json']))
       end
 
       it 'leaves minified files that dont have unminified versions' do
         expect(
           targets(['foo.min.js'])
-        ).to eq(Paths.new(['app/assets/javascripts/foobar/foo.min.js']))
+        ).to eq(Paths.new(['app/assets/javascripts/foobar.js/foo.min.js']))
       end
 
       it 'generates manifest for javascript files' do
         expect(
           targets(['foo.js'], ['foo.js'])
         ).to eq(Paths.new([
-          'app/assets/javascripts/foobar/foo.js',
+          'app/assets/javascripts/foobar.js/foo.js',
           'app/assets/javascripts/foobar.js'
         ]))
       end
@@ -83,14 +83,14 @@ module Build
           mappings(
             ['foo.js'], ['foo.js']
           )['app/assets/javascripts/foobar.js']
-        ).to include('require foobar/foo.js')
+        ).to include('require foobar.js/foo.js')
       end
 
       it 'generates manifest for stylesheet files' do
         expect(
           targets(['foo.css'], ['foo.css'])
         ).to eq(Paths.new([
-          'app/assets/stylesheets/foobar/foo.scss',
+          'app/assets/stylesheets/foobar.js/foo.scss',
           'app/assets/stylesheets/foobar.scss'
         ]))
       end
@@ -100,7 +100,7 @@ module Build
           mappings(
             ['foo.css'], ['foo.css']
           )['app/assets/stylesheets/foobar.scss']
-        ).to include("@import 'foobar/foo.scss';")
+        ).to include("@import 'foobar.js/foo.scss';")
       end
 
       it 'generates proper stylesheet manifest (font-awesome case)' do
@@ -108,7 +108,7 @@ module Build
           ['css/foo.css', 'scss/foo.scss'], ['css/foo.css']
         )['app/assets/stylesheets/foobar.scss']
 
-        expect(maps).to include("@import 'foobar/foo.scss';")
+        expect(maps).to include("@import 'foobar.js/foo.scss';")
       end
 
       it 'generates proper stylesheet manifest (multple requires)' do
@@ -117,15 +117,15 @@ module Build
           ['css/foo.css', 'scss/foo.scss'],
         )['app/assets/stylesheets/foobar.scss']
 
-        expect(maps).to include("@import 'foobar/css/foo.scss';")
-        expect(maps).to include("@import 'foobar/scss/foo.scss';")
+        expect(maps).to include("@import 'foobar.js/css/foo.scss';")
+        expect(maps).to include("@import 'foobar.js/scss/foo.scss';")
       end
 
       it 'flattens paths for if main javascript is set' do
         expect(
           targets(['dist/foo.js'], ['dist/foo.js'])
         ).to eq(Paths.new([
-          'app/assets/javascripts/foobar/foo.js',
+          'app/assets/javascripts/foobar.js/foo.js',
           'app/assets/javascripts/foobar.js'
         ]))
       end
@@ -134,7 +134,7 @@ module Build
         expect(
           targets(['dist/css/foo.css'], ['dist/css/foo.css'])
         ).to eq(Paths.new([
-          'app/assets/stylesheets/foobar/foo.scss',
+          'app/assets/stylesheets/foobar.js/foo.scss',
           'app/assets/stylesheets/foobar.scss'
         ]))
       end
@@ -146,9 +146,9 @@ module Build
             ['dist/css/foo.css', 'dist/js/foo.js']
           )
         ).to eq(Paths.new([
-          'app/assets/javascripts/foobar/foo.js',
+          'app/assets/javascripts/foobar.js/foo.js',
           'app/assets/javascripts/foobar.js',
-          'app/assets/stylesheets/foobar/foo.scss',
+          'app/assets/stylesheets/foobar.js/foo.scss',
           'app/assets/stylesheets/foobar.scss'
         ]))
       end
@@ -160,8 +160,8 @@ module Build
             ['dist/css/foo.css']
           )
         ).to eq(Paths.new([
-          'app/assets/javascripts/foobar/dist/js/foo.js',
-          'app/assets/stylesheets/foobar/foo.scss',
+          'app/assets/javascripts/foobar.js/dist/js/foo.js',
+          'app/assets/stylesheets/foobar.js/foo.scss',
           'app/assets/stylesheets/foobar.scss'
         ]))
       end
@@ -170,7 +170,7 @@ module Build
         expect(
           targets(['foo.css'])
         ).to eq(Paths.new([
-          'app/assets/stylesheets/foobar/foo.scss'
+          'app/assets/stylesheets/foobar.js/foo.scss'
         ]))
       end
 
@@ -201,8 +201,8 @@ module Build
             'min/bar/foo-require.js'
           ], ['min/bar/foo.js'])
         ).to eq(Paths.new([
-          'app/assets/javascripts/foobar/foo-require.js',
-          'app/assets/javascripts/foobar/foo.js',
+          'app/assets/javascripts/foobar.js/foo-require.js',
+          'app/assets/javascripts/foobar.js/foo.js',
           'app/assets/javascripts/foobar.js'
         ]))
       end


### PR DESCRIPTION
#276

  Additon of the function check_gem_name(gem_name) that processes names of bower
  packages  that have a dot on the name. This function removes the dot and the
  follwing it from the name if it has a dot,so the rest of the code in
  extension the function manifest_pathcan assign the proper extension, thus avoiding
  the current error in which  javascript manifest files have a double extension estring
  in their name for example Chart.js.js.

  Also the tests were modified to cover the cases with dots. To avoid repetition of tests
  the base case was changed by replacing the path 'foobar' by to 'foobar.js' thus allowing
  to tests the cases with dots without changing the functionality of the tests nor
  creating duplication of code by making tests for 'foobar' and 'foobar.js'

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rails-assets/rails-assets/299)

<!-- Reviewable:end -->
