### PR TITLE
Save 198MB of memory per request

### DIFF
--- a/app/helpers/component_helper.rb
+++ b/app/helpers/component_helper.rb
@@ -3,10 +3,7 @@ module ComponentHelper
   extend self
 
   def generate_components_json
-    ids = Version
-          .indexed
-          .select(:component_id)
-          .to_a.map(&:component_id)
+    ids = Version.indexed.pluck(:component_id)
     Component
       .includes(:versions)
       .references(:versions)


### PR DESCRIPTION
Memory reduction:

Before that line of code, 111 MB RES. Right after running that one line, was 344 MB RES.

After my fix:

Before that line of code, 111 MB RES again. Right after running that one line, was 146 RES.

I'm not sure how that really reduced this by 198 MB, but I think this is one of the main issues with the bloat. Am I missing something here?