### PR TITLE
delete instead of destroy so callback isn't run

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -62,7 +62,7 @@ class Version < ActiveRecord::Base
   after_destroy :remove_component
 
   def remove_component
-    component.destroy if component.versions.count == 0
+    component.delete if component.versions.count == 0
   end
 
   before_save :update_caches


### PR DESCRIPTION
Otherwise, with the "dependent: destroy" callback in the Component
model, this leads to a stack overflow
