### PR TITLE
Lb/fix root redirect

### DIFF
--- a/infrastructure/group_vars/primary
+++ b/infrastructure/group_vars/primary
@@ -1,3 +1,3 @@
 ---
-redis_url: "redis://{{ hostvars['therac25.rails-assets.org']['ansible_eth1']['ipv4']['address'] }}:6379/0"
-database_host: "{{ hostvars['therac25.rails-assets.org']['ansible_eth1']['ipv4']['address'] }}"
+redis_url: "redis://{{ hostvars['rails-assets.org']['ansible_eth1']['ipv4']['address'] }}:6379/0"
+database_host: "{{ hostvars['rails-assets.org']['ansible_eth1']['ipv4']['address'] }}"

--- a/infrastructure/nginx-site.conf.j2
+++ b/infrastructure/nginx-site.conf.j2
@@ -81,23 +81,4 @@ server {
     }
 }
 
-# Redirect from old rails-assets.tenex.tech
-server {
-    listen 443 ssl;
-    
-    ssl_certificate /etc/letsencrypt/live/rails-assets.tenex.tech/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/rails-assets.tenex.tech/privkey.pem;
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:50m;
-    ssl_dhparam /etc/ssl/dhparam.pem;
-    ssl_session_tickets off;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-    ssl_trusted_certificate /etc/letsencrypt/live/rails-assets.tenex.tech/fullchain.pem;
-    ssl_stapling on;
-    ssl_stapling_verify on;
-    
-    server_name rails-assets.tenex.tech;
-    return 301 https://rails-assets.org$request_uri;
-}
+

--- a/infrastructure/nginx-site.conf.j2
+++ b/infrastructure/nginx-site.conf.j2
@@ -1,55 +1,26 @@
+# -*- mode: nginx; -*-
 # rails-assets.org
-# all hosts should listen here in case of failover
-server {
-    listen 443 ssl;
-
-    ssl_certificate /etc/letsencrypt/live/rails-assets.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/rails-assets.org/privkey.pem;
-    ssl_dhparam /etc/ssl/dhparam.pem;
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:50m;
-    ssl_session_tickets off;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-    ssl_trusted_certificate /etc/letsencrypt/live/rails-assets.org/fullchain.pem;
-    ssl_stapling on;
-    ssl_stapling_verify on;
-    
-    server_name rails-assets.org;
-    root /home/rails-assets/rails-apps/rails-assets/current/public;
-    rails_env {{ rails_env }};
-    
-    passenger_enabled on;
-    passenger_min_instances 4;
-
-    # For letsencrypt
-    location ~ /.well-known {
-        allow all;
-    }
-}
-
-# secondary server
-{% if inventory_hostname != 'rails-assets.org' %}
 server {
     listen 443 ssl;
 
     ssl_certificate /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem;
+    ssl_dhparam /etc/ssl/dhparam.pem;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
-    ssl_dhparam /etc/ssl/dhparam.pem;
     ssl_session_tickets off;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_prefer_server_ciphers on;
     ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-    ssl_trusted_certificate /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem;
+
     ssl_stapling on;
     ssl_stapling_verify on;
     
     server_name {{ inventory_hostname }};
     root /home/rails-assets/rails-apps/rails-assets/current/public;
     rails_env {{ rails_env }};
+    
     passenger_enabled on;
     passenger_min_instances 4;
 

--- a/infrastructure/nginx-site.conf.j2
+++ b/infrastructure/nginx-site.conf.j2
@@ -29,12 +29,11 @@ server {
         allow all;
     }
 }
-{% endif %}
 
 # insecure.rails-assets.org
 server {
     listen 80;
-    server_name insecure.rails-assets.org;
+    server_name insecure.{{ inventory_hostname }};
     root /home/rails-assets/rails-apps/rails-assets/current/public;
     rails_env {{ rails_env }};
 

--- a/infrastructure/production
+++ b/infrastructure/production
@@ -4,10 +4,10 @@ worker
 database
 
 [web]
-therac25.rails-assets.org rails_env=production
+rails-assets.org rails_env=production ansible_ssh_host=therac25.rails-assets.org
 
 [worker]
-therac25.rails-assets.org rails_env=production
+rails-assets.org rails_env=production ansible_ssh_host=therac25.rails-assets.org
 
 [database]
-therac25.rails-assets.org
+rails-assets.org ansible_ssh_host=therac25.rails-assets.org

--- a/infrastructure/production-secondary
+++ b/infrastructure/production-secondary
@@ -3,7 +3,7 @@ web
 database
 
 [web]
-wopr.rails-assets.org rails_env=production
+rails-assets.org rails_env=production ansible_ssh_host=wopr.rails-assets.org
 
 [database]
-wopr.rails-assets.org
+rails-assets.org ansible_ssh_host=wopr.rails-assets.org

--- a/infrastructure/provision-rails-assets.yml
+++ b/infrastructure/provision-rails-assets.yml
@@ -418,33 +418,15 @@
   user: root
   hosts: web
   tasks:
-    - name: create /opt
-      file:
-        path: "/opt"
-        state: "directory"
-    - name: "install lets-encrypt-config.ini"
-      template:
-        src: "lets-encrypt-config.ini"
-        dest: "/etc/lets-encrypt-config.ini"
-        owner: "root"
-        group: "users"
-    - name: "install lets-encrypt-renew-certificate script"
-      template:
-        src: "lets-encrypt-renew-certificate"
-        dest: "/opt/lets-encrypt-renew-certificate"
-        owner: "root"
-        group: "users"
-        mode: "0740"
     - name: "generate diffie-hellman params"
       command: >-
         openssl dhparam -out /etc/ssl/dhparam.pem 2048
         creates=/etc/ssl/dhparam.pem
-    - name: lets-encrypt certificate renewal cron job
-      cron:
-        name: "renew-certificate"
-        job: "letsencrypt renew --dry-run"
-        special_time: "daily"
-        # TODO Remove --dry-run
+    # - name: lets-encrypt certificate renewal cron job
+    #   cron:
+    #     name: "renew-certificate"
+    #     job: "letsencrypt renew"
+    #     special_time: "daily"
 
 - name: configure postgres and redis
   hosts: database

--- a/infrastructure/provision-rails-assets.yml
+++ b/infrastructure/provision-rails-assets.yml
@@ -337,7 +337,7 @@
         mode: 0660
 
     - name: "Copy passenger-watchdog script"
-      copy:
+      template:
         src: "passenger-watchdog"
         dest: "/home/{{ app_name}}/passenger-watchdog"
         mode: 0770


### PR DESCRIPTION
This fixes the root redirect problem while maintaining wopr.rails-assets.org's ability to serve during a failover. 

Also it removes some broken cert renewal stuff. I should file a separate issue for that.
