### PR TITLE
Consistent with node-semver

### DIFF
--- a/app/models/build/utils.rb
+++ b/app/models/build/utils.rb
@@ -52,7 +52,18 @@ module Build
         semVerReg = /#{Regexp.escape(specifier)}\s*(\d+\.)*[x\*]/
 
         version.gsub!(semVerReg) do |match|
-          match.strip[0..-3]
+          new = match.strip[0..-3]
+
+          case specifier
+          when '>'
+            new[-1] = (new[-1].to_i + 1).to_s
+            new.gsub specifier, '>='
+          when '<='
+            new[-1] = (new[-1].to_i + 1).to_s
+            new.gsub specifier, '<'
+          else
+            new
+          end
         end
       end
 

--- a/spec/models/build/utils_spec.rb
+++ b/spec/models/build/utils_spec.rb
@@ -64,11 +64,19 @@ module Build
       end
 
       specify do
-        expect(Utils.fix_version_string('>=1.2.x <=1.4.x')).to eq(">= 1.2, <= 1.4")
+        expect(Utils.fix_version_string('>=1.2.x <=1.4.x')).to eq(">= 1.2, < 1.5")
       end
 
       specify do
-        expect(Utils.fix_version_string('>=1.2.X <=1.4.X')).to eq(">= 1.2, <= 1.4")
+        expect(Utils.fix_version_string('>=1.2.X <=1.4.X')).to eq(">= 1.2, < 1.5")
+      end
+
+      specify do
+        expect(Utils.fix_version_string('>=2.x <=4.x')).to eq(">= 2, < 5")
+      end
+
+      specify do
+        expect(Utils.fix_version_string('>=2.X <=4.X')).to eq(">= 2, < 5")
       end
 
       specify do
@@ -241,24 +249,37 @@ module Build
         # semver.satisfies('1.0.1', '>1.0.x') => false
         # semver.satisfies('1.1.0', '>1.0.x') => true
         expect(Utils.fix_version_string('>1.0.x')).
-          to eq("> 1.0")
+          to eq(">= 1.1")
       end
 
       specify do
         expect(Utils.fix_version_string('>1.0.X')).
-          to eq("> 1.0")
+          to eq(">= 1.1")
       end
 
       specify do
-        # semver.satisfies('1.0.1', '>1.0.x') => true
-        # semver.satisfies('1.1.0', '>1.0.x') => true
+        # semver.satisfies('1.0.0', '<=1.0.x') => true
+        # semver.satisfies('1.0.1', '<=1.0.x') => true
+        # semver.satisfies('1.1.0', '<=1.0.x') => false
         expect(Utils.fix_version_string('<=1.0.x')).
-          to eq("<= 1.0")
+          to eq("< 1.1")
       end
 
       specify do
         expect(Utils.fix_version_string('<=1.0.X')).
-          to eq("<= 1.0")
+          to eq("< 1.1")
+      end
+
+      specify do
+        # semver.satisfies('0.0.9', '<1.0.x') => true
+        # semver.satisfies('1.0.0', '<1.0.x') => false
+        expect(Utils.fix_version_string('<1.0.x')).
+          to eq("< 1.0")
+      end
+
+      specify do
+        expect(Utils.fix_version_string('<1.0.X')).
+          to eq("< 1.0")
       end
 
       specify do


### PR DESCRIPTION
This PR adds test cases and edge case handling to the Build::Utils#fix_version_string method when version string is like `>1.4.x` or `<=1.4.x` in source Bower packages.

Please see also #263.
