### PR TITLE
Add security note about blocks instead of global source

### DIFF
--- a/app/views/main/_content.slim
+++ b/app/views/main/_content.slim
@@ -24,7 +24,7 @@ article.section.getting-started
                 gem 'rails-assets-BOWER_PACKAGE_NAME'
               end
 
-          For added security use a block instead of global source for Rubygems too.
+          [For added security](http://collectiveidea.com/blog/archives/2016/10/06/bundlers-multiple-source-security-vulnerability/) use a block instead of global source for Rubygems too.
 
           In development, if you have issues with SSL certificates and security is not a priority, you can use the alternate endpoint `http://insecure.rails-assets.org` instead.
 

--- a/app/views/main/_content.slim
+++ b/app/views/main/_content.slim
@@ -24,6 +24,8 @@ article.section.getting-started
                 gem 'rails-assets-BOWER_PACKAGE_NAME'
               end
 
+          For added security use a block instead of global source for Rubygems too.
+
           In development, if you have issues with SSL certificates and security is not a priority, you can use the alternate endpoint `http://insecure.rails-assets.org` instead.
 
           During `bundle` `install`, if Bundler requests a&nbsp;package like this, Rails Assets’ daemon automatically&nbsp;will:

--- a/app/views/shared/_diff_gemfile.html.erb
+++ b/app/views/shared/_diff_gemfile.html.erb
@@ -1,18 +1,18 @@
 <pre class="diff"><code><span class="diff__file">Gemfile</span>
 
-source 'https://rubygems.org'
-
 <span class="diff__added-line diff__added-line--first diff__added-line--last"><b>+</b>gem 'bundler', '>= 1.8.4'</span>
 
-gem 'rails'
+<span class="diff__added-line diff__added-line--first"><b>+</b>source 'https://rubygems.org' do</span>
+&nbsp;&nbsp;gem 'rails'
 
-gem 'sass-rails'
-gem 'uglifier'
-gem 'coffee-rails'
+&nbsp;&nbsp;gem 'sass-rails'
+&nbsp;&nbsp;gem 'uglifier'
+&nbsp;&nbsp;gem 'coffee-rails'
+<span class="diff__added-line diff__added-line--last"><b>+</b>end</span>
 
-<span class="diff__added-line diff__added-line--first diff__added-line--last"><b>+</b>source 'https://<%= Rails.configuration.x.hostname %>' do</span>
-<span class="diff__added-line diff__added-line--first"><b>+</b>  gem 'rails-assets-bootstrap'</span>
+<span class="diff__added-line diff__added-line--first"><b>+</b>source 'https://<%= Rails.configuration.x.hostname %>' do</span>
+<span class="diff__added-line"><b>+</b>  gem 'rails-assets-bootstrap'</span>
 <span class="diff__added-line"><b>+</b>  gem 'rails-assets-angular'</span>
-<span class="diff__added-line diff__added-line--last"><b>+</b>  gem 'rails-assets-leaflet'</span>
+<span class="diff__added-line"><b>+</b>  gem 'rails-assets-leaflet'</span>
 <span class="diff__added-line diff__added-line--last"><b>+</b>end</span>
  </code></pre>


### PR DESCRIPTION
Added initial notes to address #379

The Gemfile diff isn't very nice now, maybe you want to present it differently.

Split in small commits so you could merge just 1 mention if you think it's too ugly.
