### PR TITLE
Rotate the production log to avoid filling disk.

### DIFF
--- a/infrastructure/logrotate-rails-assets
+++ b/infrastructure/logrotate-rails-assets
@@ -1,0 +1,8 @@
+/home/rails-assets/rails-apps/rails-assets/current/log/production.log {
+  daily
+  copytruncate
+  rotate 6
+  compress
+  nodelaycompress
+  dateext
+}

--- a/infrastructure/provision-rails-assets.yml
+++ b/infrastructure/provision-rails-assets.yml
@@ -300,6 +300,11 @@
         src: "logrotate-nginx"
         dest: "/etc/logrotate.d/nginx"
         mode: "0644"
+    - name: rails-assets production logrotate
+      copy:
+        src: "logrotate-rails-assets"
+        dest: "/etc/logrotate.d/rails-assets"
+        mode: "0644"
   handlers:
     - name: restart nginx
       service:


### PR DESCRIPTION
Rotate the production logs so that the disk does not fill up.