### PR TITLE
fix automatic SSL certificate renewal failure

### DIFF
--- a/infrastructure/lets-encrypt-renew-certificate
+++ b/infrastructure/lets-encrypt-renew-certificate
@@ -45,6 +45,7 @@ for domain in $domains; do
         echo "the certificate is up to date ($days_exp days left)."
     else
         echo "the certificate for $domain is about to expire ($days_exp days left)"
+        get-certificate $domain
         exit 0;
     fi
 done


### PR DESCRIPTION
fix automatic SSL certificate renewal failure by adding missing invocation to certificate updating routine get-certificate to cert renewal script

This PR attempts to fix #430.

Assumptions:
- The certificate renewal script got run daily
- The `get-certificate` function does not get called from elsewhere